### PR TITLE
Fix/eslint errors (ts config and turn most into warnings for now)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,20 +5,39 @@ module.exports = {
     mocha: true,
     node: true,
   },
-  plugins: ["@typescript-eslint"],
-  extends: [
-    "standard",
-    "plugin:prettier/recommended",
-    "plugin:node/recommended",
-  ],
-  parser: "@typescript-eslint/parser",
+  plugins: ['@typescript-eslint'],
+  extends: ['standard', 'plugin:prettier/recommended', 'plugin:node/recommended'],
+  parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 12,
   },
   rules: {
-    "node/no-unsupported-features/es-syntax": [
-      "error",
-      { ignores: ["modules"] },
-    ],
+    'node/no-unsupported-features/es-syntax': ['error', { ignores: ['modules'] }],
+    'no-unused-vars': 'warn',
+    'prefer-const': 'warn',
+    eqeqeq: 'warn',
+    camelcase: 'warn',
+    'spaced-comment': 'warn',
+    'node/no-unpublished-import': 'warn',
+    'node/no-unpublished-require': 'warn',
+  },
+  overrides: [
+    {
+      files: ['*.test.ts', '*.spec.ts'],
+      rules: {
+        'no-unused-expressions': 'off',
+      },
+    },
+    {
+      files: ['*.ts'],
+      rules: {
+        'node/no-extraneous-import': 'off',
+      },
+    },
+  ],
+  settings: {
+    node: {
+      tryExtensions: ['.js', '.json', '.node', '.ts', '.d.ts'],
+    },
   },
 };

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "coverage": "npm run compile && SKIP_LOAD=true hardhat coverage",
     "compile": "SKIP_LOAD=true hardhat clean && SKIP_LOAD=true hardhat compile"
   },
+  "engines": {
+    "node": ">=8.3.0"
+  },
   "devDependencies": {
     "@ethersproject/abi": "^5.6.3",
     "@ethersproject/bignumber": "^5.6.2",


### PR DESCRIPTION
Updated eslint config to prevent "all-red" in ts files because of various non-important reasons (like typechain non-camelcase factory names, etc). Most of rules turned into warnings.
Linting rules to be reviewed and standardized.